### PR TITLE
Fix: Updates requirement dependencies, replaces sum with agg

### DIFF
--- a/cashdash/dashes/assets.py
+++ b/cashdash/dashes/assets.py
@@ -46,9 +46,10 @@ class AssetDashFactory(DashBlueprintFactory):
             transactions_of_account = splits_of_account.merge(
                 transactions, left_on=TRANSACTION, right_index=True
             )
+
             transactions_of_account = transactions_of_account.groupby(
                 DATE
-            ).sum()  # aggregate for one day, use date as index
+            ).agg({VALUE:"sum"}) # aggregate for one day, use date as index
 
             asset_account_transactions.append(transactions_of_account[VALUE])
             asset_account_names.append(accounts.at[account_guid, NAME])

--- a/cashdash/dashes/cashflow.py
+++ b/cashdash/dashes/cashflow.py
@@ -325,7 +325,7 @@ class CashflowDashFactory(DashBlueprintFactory):
                 # combine splits of asset accounts into one by summing up their value in each transaction
                 asset_splits_folded = asset_splits.groupby(TRANSACTION, as_index=False)[
                     [VALUE]
-                ].sum()
+                ].agg({VALUE:"sum"})
                 asset_splits_folded[ACCOUNT] = "00000000000000000000000000000001"
                 dummy_account = pd.Series(
                     {TYPE: ASSET, NAME: "Assets", DESCRIPTION: "Dummy Asset Account"},

--- a/cashdash/dashes/expenses.py
+++ b/cashdash/dashes/expenses.py
@@ -145,7 +145,7 @@ class ExpensesDashFactory(DashBlueprintFactory):
 
                     # Aggregate by day per default, doesn't make much sense to go any more fine-grained because the
                     # finest that sample_books goes are days
-                    transactions_per_day = subtree_transactions.groupby(DATE).sum()
+                    transactions_per_day = subtree_transactions.groupby(DATE).agg({VALUE:"sum"})
                     # Apply aggregation to weeks, months, etc.
                     transactions_resampled = (
                         transactions_per_day[VALUE].resample(rule).sum()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-anytree==2.7.3
-black==19.10b0
-cvxpy==1.0.25
-dash==1.7.0
-deprecation==2.0.7
-minizinc==0.2.2
-numpy==1.18.1
-pandas==0.25.3
-plotly==4.4.1
-tabulate==0.8.6
+anytree>=2.7.3
+black>=19.10b0
+cvxpy>=1.0.25
+dash>=1.7.0
+deprecation>=2.0.7
+minizinc>=0.2.2
+numpy>=1.18.1
+pandas>=0.25.3
+plotly>=4.4.1
+tabulate>=0.8.6
 
 # must be installed manually, see README.md:
 # gnucashxml==1.0


### PR DESCRIPTION
The updated dependencies allow compiling on Fedora 35. Be aware, that lapack-devel and cmake need to be installed on the system using the package manager.

Start lead to key error 'value' when using 'sum()':

```
  File "cashdash/cashdash/dashes/assets.py", line 53, in _setup_dash
    asset_account_transactions.append(transactions_of_account[VALUE])
  File "/usr/lib64/python3.10/site-packages/pandas/core/frame.py", line 3455, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/usr/lib64/python3.10/site-packages/pandas/core/indexes/base.py", line 3363, in get_loc
    raise KeyError(key) from err
KeyError: 'value'
```
Changing 'sum()' to 'agg' solves this issue.